### PR TITLE
The angular-bootstrap bower repo changed structure

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,8 +43,7 @@
                 },
                 clear: {
                     src: [
-                        'components/angular-bootstrap/src/transition/transition.js',
-                        'components/angular-bootstrap/src/dialog/dialog.js',
+                        'components/angular-bootstrap/ui-bootstrap.js',
                         'src/<%= pkg.name %>.js'
                     ],
                     dest: 'web/assets/js/<%= pkg.name %>.js'


### PR DESCRIPTION
The single feature js files are no longer available, so without this

```
bower install
grunt
```

will cause the site to break down.
